### PR TITLE
Implement `get_or_query` mechanism

### DIFF
--- a/src/cache_provider/local_cache.rs
+++ b/src/cache_provider/local_cache.rs
@@ -1,30 +1,87 @@
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::str::FromStr;
 
 use async_trait::async_trait;
+use tracing::{error, info};
 
 use crate::cache_provider::CacheProvider;
 
 pub struct LocalCache<K: Eq + Hash, V> {
+    cache_server_url: Option<String>,
     map: HashMap<K, V>,
 }
 
 impl<K: Eq + Hash, V> LocalCache<K, V> {
-    pub fn new() -> LocalCache<K, V> {
+    pub fn new(cache_server_url: Option<String>) -> LocalCache<K, V> {
         LocalCache {
+            cache_server_url: cache_server_url,
             map: HashMap::new(),
         }
     }
 }
 
-#[async_trait]
-impl<K: Sync+Send+Eq + Hash, V:Sync+Send+Clone> CacheProvider<K, V> for LocalCache<K, V> {
+static MAX_ITERS: u32 = 32;
+
+#[async_trait(?Send)]
+impl<K: Sync + Send + Eq + Hash + ToString, V: Sync + Send + Clone + FromStr> CacheProvider<K, V>
+    for LocalCache<K, V>
+{
     async fn set(&mut self, key: K, value: V) {
         self.map.insert(key, value);
     }
 
     async fn get(&mut self, key: K) -> Option<V> {
         self.map.get(&key).map(V::to_owned)
+    }
+
+    async fn get_or_query(&mut self, key: K) -> Option<V> {
+        if let Some(v) = self.map.get(&key) {
+            return Some(v.to_owned());
+        }
+
+        let cache_server_url;
+        if let Some(url) = &self.cache_server_url {
+            cache_server_url = url;
+        } else {
+            error!("Tried `get_or_query` on LocalCache without `cache_server_url`!");
+            return None;
+        }
+
+        let mut iters = 0;
+        while iters < MAX_ITERS {
+            let client = awc::Client::new();
+            let params = [("key", "bar")];
+            let final_url =
+                "http://".to_owned() + &cache_server_url + "/cache/get?key=" + &key.to_string();
+            let request = client.get(final_url).send_form(&params);
+            let response = request.await;
+
+            let mut body = None;
+            if let Some(response_body) = response
+                .ok()
+                .filter(|response| response.status() == awc::http::StatusCode::OK)
+                .map(|mut response| response.body())
+            {
+                body = Some(response_body.await)
+            }
+
+            let value = body
+                .map(|result| result.ok())
+                .flatten()
+                .map(|bytes| String::from_utf8(bytes.to_vec()).ok())
+                .flatten()
+                .map(|string| V::from_str(&string).ok())
+                .flatten();
+            if value.is_some() {
+                info!("Found value after {} iterations", iters);
+                return value;
+            }
+
+            iters += 1;
+        }
+        error!("Could not fetch from cache after {} attempts", MAX_ITERS);
+        None
     }
 
     async fn remove(&mut self, key: K) {
@@ -40,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_set() {
-        let mut cache = LocalCache::<String, i32>::new();
+        let mut cache = LocalCache::<String, i32>::new(None);
         executor::block_on(cache.set("apples".to_string(), 5));
         executor::block_on(cache.set("strawberries".to_string(), -142));
         executor::block_on(cache.set("apples".to_string(), 3));
@@ -49,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_get_some() {
-        let mut cache = LocalCache::<String, i32>::new();
+        let mut cache = LocalCache::<String, i32>::new(None);
         executor::block_on(cache.set("apples".to_string(), 5));
         executor::block_on(cache.set("strawberries".to_string(), -142));
         executor::block_on(cache.set("apples".to_string(), 3));
@@ -58,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_get_none() {
-        let mut cache = LocalCache::<String, i32>::new();
+        let mut cache = LocalCache::<String, i32>::new(None);
         executor::block_on(cache.set("apples".to_string(), 5));
         executor::block_on(cache.set("strawberries".to_string(), -142));
         executor::block_on(cache.set("apples".to_string(), 3));
@@ -67,7 +124,7 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut cache = LocalCache::<String, i32>::new();
+        let mut cache = LocalCache::<String, i32>::new(None);
         executor::block_on(cache.set("apples".to_string(), 5));
         executor::block_on(cache.set("strawberries".to_string(), -142));
         executor::block_on(cache.set("apples".to_string(), 3));

--- a/src/cache_provider/mod.rs
+++ b/src/cache_provider/mod.rs
@@ -15,9 +15,10 @@ pub struct CacheSetRequest<K, V> {
     pub value: V,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait CacheProvider<K, V> {
     async fn set(&mut self, key: K, value: V);
     async fn get(&mut self, key: K) -> Option<V>;
+    async fn get_or_query(&mut self, key: K) -> Option<V>;
     async fn remove(&mut self, key: K);
 }

--- a/src/cache_provider/redis_cache.rs
+++ b/src/cache_provider/redis_cache.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use redis::{aio::Connection, RedisError, RedisResult};
 use redis::{AsyncCommands, FromRedisValue, ToRedisArgs};
-use tracing::{info, error};
+use tracing::{error, info};
 
 use crate::cache_provider::CacheProvider;
 
@@ -14,21 +14,21 @@ impl RedisCache {
         let client = redis::Client::open(url).unwrap();
         let con = client.get_async_connection().await.unwrap();
 
-        RedisCache {
-            con: con,
-        }
+        RedisCache { con: con }
     }
 }
 
 #[async_trait(?Send)]
-impl<K: Sync + Send + ToRedisArgs + 'static, V: Sync + Send + ToRedisArgs + FromRedisValue + 'static>
-    CacheProvider<K , V> for RedisCache
+impl<
+        K: Sync + Send + ToRedisArgs + 'static,
+        V: Sync + Send + ToRedisArgs + FromRedisValue + 'static,
+    > CacheProvider<K, V> for RedisCache
 {
     async fn set(&mut self, key: K, value: V) {
         let ret: Result<(), RedisError> = self.con.set(key, value).await;
         match ret {
             Ok(_) => (),
-            Err(e) => error!("Set failed at: {}", e)
+            Err(e) => error!("Set failed at: {}", e),
         }
     }
 
@@ -39,7 +39,7 @@ impl<K: Sync + Send + ToRedisArgs + 'static, V: Sync + Send + ToRedisArgs + From
             Err(e) => {
                 error!("Get failed at: {}", e);
                 None
-            },
+            }
         }
     }
 
@@ -53,14 +53,14 @@ impl<K: Sync + Send + ToRedisArgs + 'static, V: Sync + Send + ToRedisArgs + From
             Ok(_) => (),
             Err(e) => {
                 error!("Get failed at: {}", e);
-            },
+            }
         }
     }
 }
 #[cfg(test)]
 mod tests {
-    use std::env;
     use serial_test::serial;
+    use std::env;
 
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
@@ -68,8 +68,8 @@ mod tests {
     async fn get_cache() -> Box<dyn CacheProvider<String, i32>> {
         let password;
         match env::var("REDIS_PASSWORD") {
-            Ok(v) => password=v,
-            Err(_) => panic!("$REDIS_PASSWORD is not set!")
+            Ok(v) => password = v,
+            Err(_) => panic!("$REDIS_PASSWORD is not set!"),
         };
 
         let url = "redis://default:".to_string() + &password + "@127.0.0.1:6379";

--- a/src/cache_provider/redis_cache.rs
+++ b/src/cache_provider/redis_cache.rs
@@ -20,7 +20,7 @@ impl RedisCache {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<K: Sync + Send + ToRedisArgs + 'static, V: Sync + Send + ToRedisArgs + FromRedisValue + 'static>
     CacheProvider<K , V> for RedisCache
 {
@@ -41,6 +41,10 @@ impl<K: Sync + Send + ToRedisArgs + 'static, V: Sync + Send + ToRedisArgs + From
                 None
             },
         }
+    }
+
+    async fn get_or_query(&mut self, key: K) -> Option<V> {
+        self.get(key).await
     }
 
     async fn remove(&mut self, key: K) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,11 @@ async fn cache_set(
 }
 
 #[get("/{tail:.*}")]
-async fn get_proxy(data: web::Data<Mutex<AppState>>, path: web::Path<String>, bytes: Bytes) -> HttpResponse {
+async fn get_proxy(
+    request: actix_web::HttpRequest,
+    data: web::Data<Mutex<AppState>>,
+    path: web::Path<String>, 
+    bytes: Bytes) -> HttpResponse {
     // TODO: unpacking username from http request will be different, it has to be planned out
     let mut data = data.lock().await;
     let url;
@@ -102,7 +106,12 @@ async fn get_proxy(data: web::Data<Mutex<AppState>>, path: web::Path<String>, by
     if let Some(url) = url {
         let client = awc::Client::default();
 
-        let final_url = "http://".to_owned() + &url + "/" + &path.into_inner();
+        let mut final_url = "http://".to_owned() + &url + "/" + &path.into_inner();
+        if  request.query_string() != "" {
+            final_url += "?";
+            final_url += request.query_string();
+        }
+
         let res = client.get(final_url).send_body(bytes).await.unwrap();
         res.into_http_response()
     } else {
@@ -111,7 +120,11 @@ async fn get_proxy(data: web::Data<Mutex<AppState>>, path: web::Path<String>, by
 }
 
 #[post("/{tail:.*}")]
-async fn post_proxy(data: web::Data<Mutex<AppState>>, path: web::Path<String>, bytes: Bytes) -> HttpResponse {
+async fn post_proxy(
+    request: actix_web::HttpRequest,
+    data: web::Data<Mutex<AppState>>, 
+    path: web::Path<String>, 
+    bytes: Bytes) -> HttpResponse {
     // TODO: unpacking username from http request will be different, it has to be planned out
     let mut data = data.lock().await;
     let url;
@@ -124,7 +137,12 @@ async fn post_proxy(data: web::Data<Mutex<AppState>>, path: web::Path<String>, b
     if let Some(url) = url {
         let client = awc::Client::default();
 
-        let final_url = "http://".to_owned() + &url + "/" + &path.into_inner();
+        let mut final_url = "http://".to_owned() + &url + "/" + &path.into_inner();
+        if  request.query_string() != "" {
+            final_url += "?";
+            final_url += request.query_string();
+        }
+        
         let res = client.post(final_url).send_body(bytes).await.unwrap();
         res.into_http_response()
     } else {


### PR DESCRIPTION
Added #[async_trait(?Send)] to CacheProvider implementations, so we do not have to worry about having Send everywhere.
![obraz](https://github.com/group-project-gut/lynx-balancer/assets/56126596/7d5fe9cc-6e6d-456c-9b7a-034dff4be6d3)
